### PR TITLE
Fallback for crypto.randomUUID in InterestCalculator

### DIFF
--- a/InterestCalculator.jsx
+++ b/InterestCalculator.jsx
@@ -46,7 +46,20 @@ function escapeCsv(val) {
   }
   return s;
 }
-const blankRow = (type = "payment") => ({ id: crypto.randomUUID(), date: "", type, amount: "", note: "", source: "direct" });
+function generateId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback for browsers without crypto.randomUUID.
+  // Uses Math.random and is not cryptographically secure.
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+const blankRow = (type = "payment") => ({ id: generateId(), date: "", type, amount: "", note: "", source: "direct" });
 
 // ========================= Component =========================
 export default function InterestCalculator() {

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Simple Interest Calculator
+
+A simple React-based calculator for computing interest schedules.
+
+## Browser Requirements
+
+This component attempts to use [`crypto.randomUUID`](https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID) when generating IDs for new rows. Browsers without this API fall back to a basic `Math.random` implementation, which is not cryptographically secure. For the best experience, use a modern browser with `crypto.randomUUID` support.
+


### PR DESCRIPTION
## Summary
- generate unique row IDs with crypto.randomUUID when available
- add Math.random fallback and document requirement
- note browser expectation in README

## Testing
- `node escapeCsv.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b38313b8488326934cab15c06cad04