### PR TITLE
Ensure CV93 signer default uses local date

### DIFF
--- a/InterestCalculator.jsx
+++ b/InterestCalculator.jsx
@@ -247,7 +247,7 @@ export default function InterestCalculator() {
       },
       payments,
       carryForwards,
-      signer: { name: signer.name, dateISO: signer.dateISO || period.thruISO || fmtDateISO(new Date().toISOString()) },
+      signer: { name: signer.name, dateISO: signer.dateISO || period.thruISO || fmtDateISO(new Date()) },
     };
   }
 


### PR DESCRIPTION
## Summary
- Use `fmtDateISO(new Date())` to determine default signer date in CV93 payload, ensuring local timezone is honored

## Testing
- `node escapeCsv.test.js`
- `TZ=America/Los_Angeles node -e "..."`
- `TZ=Pacific/Kiritimati node -e "..."`


------
https://chatgpt.com/codex/tasks/task_e_68b386dd5b588326be6aef13353c4c1a