### PR TITLE
Add configurable PDF font size

### DIFF
--- a/InterestCalculator.jsx
+++ b/InterestCalculator.jsx
@@ -56,6 +56,19 @@ export default function InterestCalculator() {
   const BASIS = 365;
   const [asOfDate, setAsOfDate] = useState("");
   const [rows, setRows] = useState([blankRow("payment")]);
+  const [pdfFontSize, setPdfFontSize] = useState(12);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("pdfFontSize");
+    if (stored) {
+      const n = parseInt(stored, 10);
+      if (Number.isFinite(n)) setPdfFontSize(n);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("pdfFontSize", String(pdfFontSize));
+  }, [pdfFontSize]);
 
 
   // Auto-add new blank row once last row has both date & amount
@@ -138,6 +151,7 @@ export default function InterestCalculator() {
 
   function printPDF() {
     const pdf = new jsPDF();
+    pdf.setFontSize(pdfFontSize);
     let y = 10;
     pdf.text(`Case: ${caseName}`, 10, y); y += 10;
     pdf.text(`Debtor: ${debtor}`, 10, y); y += 10;
@@ -325,6 +339,13 @@ export default function InterestCalculator() {
               </ol>
             </div>
               <div className="flex justify-end mt-auto pt-6 space-x-2">
+                <input
+                  type="number"
+                  aria-label="PDF font size"
+                  value={pdfFontSize}
+                  onChange={(e) => setPdfFontSize(Number(e.target.value))}
+                  className="w-16 px-2 py-1 rounded-xl border shadow-sm text-sm"
+                />
                 <button onClick={printPDF} className="flex items-center space-x-2 px-4 py-2 rounded-xl border shadow-sm hover:bg-gray-50 transition-colors">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-5 h-5">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.506 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5Zm-3 0h.008v.008H15V10.5Z" />


### PR DESCRIPTION
## Summary
- allow users to adjust PDF font size via a new numeric input
- remember chosen font size using `localStorage`
- apply the selected size in generated PDFs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b47be3772c83269acf96ac4e64c686