### PR TITLE
Add totals summary to PDF output

### DIFF
--- a/InterestCalculator.jsx
+++ b/InterestCalculator.jsx
@@ -192,6 +192,28 @@ export default function InterestCalculator() {
       theme: "grid",
     });
 
+    // After the schedule table, output totals aligned at the end of the document
+    const finalY = pdf.lastAutoTable?.finalY || y;
+    const lines = [
+      `Principal (current): ${currency(schedule.totals.principal)}`,
+      `Unpaid Interest (carryover): ${currency(schedule.totals.carryInterest)}`,
+      `Total Due (as of ${fmtDateISO(asOfDate) || 'latest entry'}): ${currency(schedule.totals.balance)}`,
+    ];
+
+    let startY = finalY + 10; // add spacing after table
+    const lineHeight = pdf.getLineHeight() / pdf.internal.scaleFactor;
+    const bottomMargin = 10;
+    const pageHeight = pdf.internal.pageSize.getHeight();
+
+    if (startY + lines.length * lineHeight > pageHeight - bottomMargin) {
+      pdf.addPage();
+      startY = 10;
+    }
+
+    lines.forEach((text, i) => {
+      pdf.text(text, 10, startY + i * lineHeight);
+    });
+
     pdf.save(`${caseName || "schedule"}.pdf`);
   }
 


### PR DESCRIPTION
## Summary
- Append current principal, carryover interest, and total due to the PDF after the schedule table.
- Ensure totals start on a new page if space is insufficient.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b47d8de6e08326879a030b5e9d14c5