### PR TITLE
Add home navigation to tools

### DIFF
--- a/InterestCalculator.jsx
+++ b/InterestCalculator.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 
@@ -311,8 +312,14 @@ function printPDF() {
 			  <h1 className="text-lg font-semibold tracking-tight">Simple Interest Calculator</h1>
 			  <p className="text-xs text-white/70">Matter finance · daily simple interest · printable ledgers</p>
 			</div>
-			<div className="flex items-center gap-2">
-			  {/* Dark mode toggle with persistence */}
+                        <div className="flex items-center gap-2">
+                          <Link
+                                to="/"
+                                className="px-3 py-1.5 rounded-xl border border-white/20 text-sm hover:bg-white/10"
+                          >
+                                Home
+                          </Link>
+                          {/* Dark mode toggle with persistence */}
 			  <button
 				type="button"
 				onClick={() => {

--- a/src/CaseValuator.jsx
+++ b/src/CaseValuator.jsx
@@ -1,10 +1,25 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 export default function CaseValuator() {
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-semibold mb-4">Case Valuator</h1>
-      <p>Coming soon.</p>
-    </div>
+    <>
+      <header className="sticky top-0 z-30 bg-ink text-white border-b border-black/20">
+        <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
+          <h1 className="text-lg font-semibold tracking-tight">Case Valuator</h1>
+          <Link
+            to="/"
+            className="px-3 py-1.5 rounded-xl border border-white/20 text-sm hover:bg-white/10"
+          >
+            Home
+          </Link>
+        </div>
+      </header>
+      <div className="min-h-screen p-8 bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-100">
+        <div className="max-w-3xl mx-auto">
+          <p>Coming soon.</p>
+        </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Add Tailwind-styled Home link to Interest Calculator header
- Introduce consistent header with Home link to Case Valuator page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6380b80d48326803ef2d22f3fb286